### PR TITLE
Extend prototype with non-enumerable property

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function extendObjectPrototype (hideWarnings) {
           args.unshift(this); // sets first arg as object instance
           return method.apply(this, args);
         },
+        enumerable: false,
         configurable: envIs('test') // hack for tests
       });
     }


### PR DESCRIPTION
This way we don't mess up peoples' code depending on `for..in` or `Object.keys`. Many people rely on Object.prototype having no enumerable properties and do things like:

```js
for (key in {a:1, b:2}) foo(key);
```

More info on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).